### PR TITLE
Use regex for carriage return in windows

### DIFF
--- a/lib/themeroller-image.js
+++ b/lib/themeroller-image.js
@@ -346,7 +346,7 @@ async.series([
 			if ( !(/ImageMagick/).test( output ) ) {
 				return callback( new Error( "ImageMagick not installed.\n" + output ) );
 			}
-			imVersion = output.split( "\n" )[ 0 ].replace( /^Version: ImageMagick ([^ ]*).*/, "$1" );
+			imVersion = output.split( /\r?\n/ )[ 0 ].replace( /^Version: ImageMagick ([^ ]*).*/, "$1" );
 			if ( !semver.valid( imVersion ) ) {
 				return callback( new Error( "Could not identify ImageMagick version.\n" + output ) );
 			}


### PR DESCRIPTION
In windows env, the ImageMagick version string is containing \r\n at the end of each line, split and replace methods are keeping this \r leading to an issue with semver.valid() returning false because extracted imVersion is something like '6.9.3-2\r'